### PR TITLE
License fixes

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,5 +1,7 @@
 The MIT License (MIT)
-Copyright (C) 2014 HM Government (DEFRA)
+=====================
+
+Copyright (c) 2015 Crown Copyright
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -18,4 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-


### PR DESCRIPTION
All code produced by the government belongs to "Crown Copyright" not the department.
License is spelt with an S
Markdown licenses are a thing and they are a pretty thing
The year is 2015
